### PR TITLE
Complete SSE int32 and mask32 impl as per the disucssion below

### DIFF
--- a/SSE/constants.h
+++ b/SSE/constants.h
@@ -1,0 +1,23 @@
+// -*- C++ Header -*-
+/*
+==================================================
+Authors: A.Mithran;
+Emails: mithran@fias.uni-frankfurt.de
+==================================================
+*/
+
+#ifndef SIMD_SSE_CONSTANTS_H
+#define SIMD_SSE_CONSTANTS_H
+
+#include <cstddef>
+
+namespace KFP {
+namespace SIMD {
+
+constexpr std::size_t SimdSize{16};
+constexpr std::size_t SimdLen{4};
+
+} // namespace SIMD
+} // namespace KFP
+
+#endif // !SIMD_SSE_CONSTANTS_H

--- a/SSE/float32.h
+++ b/SSE/float32.h
@@ -11,9 +11,9 @@ Emails: mithran@fias.uni-frankfurt.de
 
 #include "../Utils/macros.h"
 #include "../Utils/tag.h"
+#include "mask32.h"
 
 #include <iostream>
-#include <x86intrin.h>
 #include <cmath>
 #include <string>
 #include <cassert>
@@ -21,7 +21,7 @@ Emails: mithran@fias.uni-frankfurt.de
 namespace KFP {
 namespace SIMD {
 
-__KFP_SIMD__INLINE __m128 select(const __m128& mask, const __m128& a,
+KFP_SIMD__INLINE __m128 select(const __m128& mask, const __m128& a,
                                     const __m128& b);
 
 class Float32_128

--- a/SSE/int32.h
+++ b/SSE/int32.h
@@ -12,14 +12,16 @@ Emails: mithran@fias.uni-frankfurt.de
 #include "../Utils/macros.h"
 #include "../Utils/tag.h"
 #include "mask32.h"
+#include "constants.h"
 
+#include <cstdint>
 #include <string>
 #include <cassert>
 
 namespace KFP {
 namespace SIMD {
 
-KFP_SIMD__INLINE __m128i select_(const __m128i& mask, const __m128i& a,
+KFP_SIMD_INLINE __m128i select_(const __m128i& mask, const __m128i& a,
                                     const __m128i& b) {
     return _mm_blendv_epi8(b, a, mask);
 }
@@ -27,111 +29,105 @@ KFP_SIMD__INLINE __m128i select_(const __m128i& mask, const __m128i& a,
 class Int32_128
 {
 public:
-    typedef int value_type;
+    typedef std::int32_t value_type;
     typedef __m128i simd_type;
     static constexpr Tag tag{ Tag::SSE };
-    static constexpr int SimdSize{ sizeof(simd_type) };
-    static constexpr int SimdLen{ SimdSize / sizeof(value_type) };
 
     // ------------------------------------------------------
     // Constructors
     // ------------------------------------------------------
     // Default constructor:
-    Int32_128() {}
+    Int32_128() {
+        m_data = _mm_setzero_si128();
+    }
+    Int32_128(UninitializeTag) {}
     // Constructor to broadcast the same value into all elements:
-    Int32_128(value_type val)
+    Int32_128(std::int32_t val)
     {
-        data_ = _mm_set1_epi32(val);
+        m_data = _mm_set1_epi32(val);
     }
-    Int32_128(simd_type val_simd)
+    Int32_128(__m128i val_simd)
     {
-        data_ = val_simd;
+        m_data = val_simd;
     }
-    Int32_128(const value_type* val_ptr)
+    Int32_128(const std::int32_t* val_ptr)
     {
-        data_ = _mm_loadu_si128(reinterpret_cast<const simd_type*>(val_ptr));
+        m_data = _mm_loadu_si128(reinterpret_cast<const __m128i*>(val_ptr));
     }
-    Int32_128(const Int32_128& class_simd)
-    {
-        data_ = class_simd.data_;
-    }
+    Int32_128(const Int32_128& class_simd) = default;
 
     // Assignment constructors:
-    Int32_128& operator=(value_type val)
+    Int32_128& operator=(std::int32_t val)
     {
-        data_ = _mm_set1_epi32(val);
+        m_data = _mm_set1_epi32(val);
         return *this;
     }
-    Int32_128& operator=(const simd_type& val_simd)
+    Int32_128& operator=(const __m128i& val_simd)
     {
-        data_ = val_simd;
+        m_data = val_simd;
         return *this;
     }
-    Int32_128& operator=(const Int32_128& class_simd)
-    {
-        data_ = class_simd.data_;
-        return *this;
-    }
+    Int32_128& operator=(const Int32_128& class_simd) = default;
 
     // ------------------------------------------------------
     // Factory methods
     // ------------------------------------------------------
-    KFP_SIMD__INLINE static Int32_128 indicesSequence(value_type start)
+    KFP_SIMD_INLINE static Int32_128 indicesSequence(std::int32_t start)
     {
-        KFP_SIMD__SPEC_ALIGN(SimdSize) constexpr value_type
-        data[SimdLen]{0, 1, 2, 3}; // Helper data array
-        return Int32_128{}.load_a(data) + start;
+        return Int32_128{
+            _mm_add_epi32(_mm_setr_epi32(0, 1, 2, 3), _mm_set1_epi32(start))
+        };
     }
 
     // ------------------------------------------------------
     // Load and Store
     // ------------------------------------------------------
     // Member function to load from array (unaligned)
-    KFP_SIMD__INLINE Int32_128& load(const value_type* val_ptr)
+    KFP_SIMD_INLINE Int32_128& loadUnaligned(const std::int32_t* val_ptr)
     {
-        data_ = _mm_loadu_si128(reinterpret_cast<const simd_type*>(val_ptr));
+        m_data = _mm_loadu_si128(reinterpret_cast<const __m128i*>(val_ptr));
         return *this;
     }
     // Member function to load from array (aligned)
-    KFP_SIMD__INLINE Int32_128& load_a(const value_type* val_ptr)
+    KFP_SIMD_INLINE Int32_128& load(const std::int32_t* val_ptr)
     {
-        data_ = _mm_load_si128(reinterpret_cast<const simd_type*>(val_ptr));
+        m_data = _mm_load_si128(reinterpret_cast<const __m128i*>(val_ptr));
         return *this;
     }
     // Member function to store into array (unaligned)
-    KFP_SIMD__INLINE void store(value_type* val_ptr) const
+    KFP_SIMD_INLINE void storeUnaligned(std::int32_t* val_ptr) const
     {
-        _mm_storeu_si128(reinterpret_cast<simd_type*>(val_ptr), data_);
+        _mm_storeu_si128(reinterpret_cast<__m128i*>(val_ptr), m_data);
     }
     // Member function storing into array (aligned)
-    KFP_SIMD__INLINE void store_a(value_type* val_ptr) const
+    KFP_SIMD_INLINE void store(std::int32_t* val_ptr) const
     {
-        _mm_store_si128(reinterpret_cast<simd_type*>(val_ptr), data_);
+        _mm_store_si128(reinterpret_cast<__m128i*>(val_ptr), m_data);
     }
 
     // ------------------------------------------------------
     // Gather and Scatter
     // ------------------------------------------------------
-    KFP_SIMD__INLINE Int32_128& gather(const value_type* val_ptr, const Int32_128& index)
+    KFP_SIMD_INLINE Int32_128& gather(const std::int32_t* val_ptr, const Int32_128& index)
     {
-        KFP_SIMD__SPEC_ALIGN(SimdSize) value_type
+        alignas(SimdSize) std::int32_t
         indices[SimdLen]{}; // Helper indices array
-        index.store_a(indices);
-        data_ = _mm_setr_epi32(
+        index.store(indices);
+        m_data = _mm_setr_epi32(
             val_ptr[indices[0]], val_ptr[indices[1]],
             val_ptr[indices[2]], val_ptr[indices[3]]
         );
         return *this;
     }
-    KFP_SIMD__INLINE void scatter(value_type* val_ptr, const Int32_128& index) const
+    KFP_SIMD_INLINE void scatter(std::int32_t* val_ptr, const Int32_128& index) const
     {
-        KFP_SIMD__SPEC_ALIGN(SimdSize) value_type
+        alignas(SimdSize) std::int32_t
         data[SimdLen]{}; // Helper data array
-        store_a(data);
+        store(data);
 
-        KFP_SIMD__SPEC_ALIGN(SimdSize) int
+        alignas(SimdSize) int
         indices[SimdLen]{}; // Helper indices array
-        index.store_a(indices);
+        index.store(indices);
 
         val_ptr[indices[0]] = data[0];
         val_ptr[indices[1]] = data[1];
@@ -142,26 +138,21 @@ public:
     // ------------------------------------------------------
     // Data member accessors
     // ------------------------------------------------------
-    KFP_SIMD__INLINE simd_type& simd()
+    KFP_SIMD_INLINE __m128i& simd()
     {
-        return data_;
+        return m_data;
     }
-    KFP_SIMD__INLINE const simd_type& simd() const
+    KFP_SIMD_INLINE const __m128i& simd() const
     {
-        return data_;
+        return m_data;
     }
     template <int N>
-    KFP_SIMD__INLINE value_type get(simd_type a) const {
+    KFP_SIMD_INLINE std::int32_t get(__m128i a) const {
         static_assert(N < SimdLen,
         "[Error] (Int32_128::get): Invalid value of index to access N given");
-#if 1
-        return _mm_extract_epi32(data_, N);
-#else
-        const simd_type result = _mm_shuffle_epi32(a, N);
-        return _mm_cvtsi128_si32(result);
-#endif
+        return _mm_extract_epi32(m_data, N);
     }
-    KFP_SIMD__INLINE value_type operator[](int index) const
+    KFP_SIMD_INLINE std::int32_t operator[](int index) const
     {
         assert((index >= 0) && ("[Error] (Int32_128::operator[]): invalid index (" +
                std::to_string(index) + ") given. Negative")
@@ -170,9 +161,9 @@ public:
                ("[Error] (Int32_128::operator[]): invalid index (" + std::to_string(index) +
                ") given. Exceeds maximum")
                .data());
-        KFP_SIMD__SPEC_ALIGN(SimdSize) value_type
+        alignas(SimdSize) std::int32_t
         data[SimdLen]{}; // Helper array
-        store_a(data);
+        store(data);
         return data[index];
     }
 
@@ -184,118 +175,111 @@ public:
     // ------------------------------------------------------
     // Data lanes manipulation
     // ------------------------------------------------------
-    KFP_SIMD__INLINE friend Int32_128 select(const Mask32_128& mask, const Int32_128& a,
+    KFP_SIMD_INLINE friend Int32_128 select(const Mask32_128& mask, const Int32_128& a,
                                        const Int32_128& b) {
-        return select_(mask.data_, a.data_, b.data_);
+        return select_(mask.m_data, a.m_data, b.m_data);
     }
 
-    KFP_SIMD__INLINE Int32_128 sign() const
+    KFP_SIMD_INLINE Int32_128 sign() const
     {
         return Int32_128{
-            _mm_and_si128(_mm_set1_epi32(0x80000000), data_)
+            _mm_and_si128(_mm_set1_epi32(0x80000000), m_data)
         };
     }
-    KFP_SIMD__INLINE Int32_128& shiftLeft(int n)
+    KFP_SIMD_INLINE Int32_128& shiftLeft(int n)
     {
         constexpr int value_size_bytes = sizeof(int);
         switch (n) {
             case 0:
                 return *this;
             case 1:
-                data_ = _mm_bsrli_si128(data_, value_size_bytes);
+                m_data = _mm_bsrli_si128(m_data, value_size_bytes);
             case 2:
-                data_ = _mm_bsrli_si128(data_, 2 * value_size_bytes);
+                m_data = _mm_bsrli_si128(m_data, 2 * value_size_bytes);
             case 3:
-                data_ = _mm_bsrli_si128(data_, 3 * value_size_bytes);
+                m_data = _mm_bsrli_si128(m_data, 3 * value_size_bytes);
             default:
-                data_ = _mm_set1_epi32(0);
+                m_data = _mm_set1_epi32(0);
         }
         return *this;
     }
-    KFP_SIMD__INLINE Int32_128& shiftRight(int n)
+    KFP_SIMD_INLINE Int32_128& shiftRight(int n)
     {
         constexpr int value_size_bytes = sizeof(int);
         switch (n) {
             case 0:
                 return *this;
             case 1:
-                data_ = _mm_bslli_si128(data_, value_size_bytes);
+                m_data = _mm_bslli_si128(m_data, value_size_bytes);
             case 2:
-                data_ = _mm_bslli_si128(data_, 2 * value_size_bytes);
+                m_data = _mm_bslli_si128(m_data, 2 * value_size_bytes);
             case 3:
-                data_ = _mm_bslli_si128(data_, 3 * value_size_bytes);
+                m_data = _mm_bslli_si128(m_data, 3 * value_size_bytes);
             default:
-                data_ = _mm_set1_epi32(0);
+                m_data = _mm_set1_epi32(0);
         }
         return *this;
     }
-
-    // ------------------------------------------------------
-    // Print I/O
-    // ------------------------------------------------------
 
     // ------------------------------------------------------
     // Basic Arithmetic
     // ------------------------------------------------------
     friend Int32_128 operator-(const Int32_128& a)
     {
-        return Int32_128{ _mm_sub_epi32(_mm_setzero_si128(), a.data_) };
+        return Int32_128{ _mm_sub_epi32(_mm_setzero_si128(), a.m_data) };
     }
     friend Int32_128 operator+(const Int32_128& a,
                                    const Int32_128& b)
     {
-        return Int32_128{ _mm_add_epi32(a.data_, b.data_) };
+        return Int32_128{ _mm_add_epi32(a.m_data, b.m_data) };
     }
-    friend Int32_128& operator+=(Int32_128& a,
-                                   const Int32_128& b)
+    Int32_128& operator+=(const Int32_128& a)
     {
-        a = a + b;
-        return a;
+        *this = *this + a;
+        return *this;
     }
     friend Int32_128 operator-(const Int32_128& a,
                                    const Int32_128& b)
     {
-        return Int32_128{ _mm_sub_epi32(a.data_, b.data_) };
+        return Int32_128{ _mm_sub_epi32(a.m_data, b.m_data) };
     }
-    friend Int32_128& operator-=(Int32_128& a,
-                                   const Int32_128& b)
+    Int32_128& operator-=(const Int32_128& a)
     {
-        a = a - b;
-        return a;
+        *this = *this - a;
+        return *this;
     }
     friend Int32_128 operator*(const Int32_128& a,
                                    const Int32_128& b)
     {
-        return _mm_mullo_epi32(a.data_, b.data_);
+        return _mm_mullo_epi32(a.m_data, b.m_data);
     }
-    friend Int32_128& operator*=(Int32_128& a,
-                                   const Int32_128& b)
+    Int32_128& operator*=(const Int32_128& a)
     {
-        a = a * b;
-        return a;
+        *this = *this * a;
+        return *this;
     }
-    friend Int32_128 operator<<(const Int32_128& a, int n)
+    Int32_128 operator<<(int n)
     {
-        return _mm_slli_epi32(a.data_, n);
+        return _mm_slli_epi32(m_data, n);
     }
-    friend Int32_128 operator>>(const Int32_128& a, int n)
+    Int32_128 operator>>(int n)
     {
-        return _mm_sra_epi32(a.data_, _mm_cvtsi32_si128(n));
+        return _mm_sra_epi32(m_data, _mm_cvtsi32_si128(n));
     }
     friend Int32_128 operator&(const Int32_128& a,
                                    const Int32_128& b)
     {
-        return _mm_and_si128(a.data_, b.data_);
+        return _mm_and_si128(a.m_data, b.m_data);
     }
     friend Int32_128 operator|(const Int32_128& a,
                                    const Int32_128& b)
     {
-        return _mm_or_si128(a.data_, b.data_);
+        return _mm_or_si128(a.m_data, b.m_data);
     }
     friend Int32_128 operator^(const Int32_128& a,
                                    const Int32_128& b)
     {
-        return _mm_xor_si128(a.data_, b.data_);
+        return _mm_xor_si128(a.m_data, b.m_data);
     }
 
     // Comparison (mask returned)
@@ -303,60 +287,60 @@ public:
                                    const Int32_128& b)
     {
         Mask32_128 result;
-        result.data_ = _mm_cmplt_epi32(a.data_, b.data_);
+        result.m_data = _mm_cmplt_epi32(a.m_data, b.m_data);
         return result;
     }
     friend Mask32_128 operator<=(const Int32_128& a,
                                     const Int32_128& b)
     {
         Mask32_128 result;
-        result.data_ = _mm_cmpeq_epi32(_mm_min_epi32(a.data_, b.data_), a.data_);
+        result.m_data = _mm_cmpeq_epi32(_mm_min_epi32(a.m_data, b.m_data), a.m_data);
         return result;
     }
     friend Mask32_128 operator>(const Int32_128& a,
                                    const Int32_128& b)
     {
         Mask32_128 result;
-        result.data_ = _mm_cmpgt_epi32(a.data_, b.data_);
+        result.m_data = _mm_cmpgt_epi32(a.m_data, b.m_data);
         return result;
     }
     friend Mask32_128 operator>=(const Int32_128& a,
                                     const Int32_128& b)
     {
         Mask32_128 result;
-        result.data_ = _mm_cmpeq_epi32(_mm_min_epi32(b.data_, a.data_), b.data_);
+        result.m_data = _mm_cmpeq_epi32(_mm_min_epi32(b.m_data, a.m_data), b.m_data);
         return result;
     }
     friend Mask32_128 operator==(const Int32_128& a,
                                     const Int32_128& b)
     {
         Mask32_128 result;
-        result.data_ = _mm_cmpeq_epi32(a.data_, b.data_);
+        result.m_data = _mm_cmpeq_epi32(a.m_data, b.m_data);
         return result;
     }
     friend Mask32_128 operator!=(const Int32_128& a,
                                     const Int32_128& b)
     {
         Mask32_128 result;
-        result.data_ = _mm_cmpeq_epi32(a.data_, b.data_);
+        result.m_data = _mm_cmpeq_epi32(a.m_data, b.m_data);
         return not result;
     }
 
-    KFP_SIMD__INLINE friend Int32_128 min(const Int32_128& a, const Int32_128& b)
+    KFP_SIMD_INLINE friend Int32_128 min(const Int32_128& a, const Int32_128& b)
     {
-        return _mm_min_epi32(a.data_, b.data_);
+        return _mm_min_epi32(a.m_data, b.m_data);
     }
-    KFP_SIMD__INLINE friend Int32_128 max(const Int32_128& a, const Int32_128& b)
+    KFP_SIMD_INLINE friend Int32_128 max(const Int32_128& a, const Int32_128& b)
     {
-        return _mm_max_epi32(a.data_, b.data_);
+        return _mm_max_epi32(a.m_data, b.m_data);
     }
-    KFP_SIMD__INLINE friend Int32_128 abs(const Int32_128& a)
+    KFP_SIMD_INLINE friend Int32_128 abs(const Int32_128& a)
     {
-        return _mm_abs_epi32(a.data_);
+        return _mm_abs_epi32(a.m_data);
     }
 
 private:
-    KFP_SIMD__SPEC_ALIGN(SimdSize) simd_type data_;
+    alignas(SimdSize) __m128i m_data;
 };
 
 } // namespace SIMD

--- a/SSE/int32.h
+++ b/SSE/int32.h
@@ -13,7 +13,6 @@ Emails: mithran@fias.uni-frankfurt.de
 #include "../Utils/tag.h"
 #include "mask32.h"
 
-#include <iostream>
 #include <string>
 #include <cassert>
 
@@ -77,15 +76,11 @@ public:
     // ------------------------------------------------------
     // Factory methods
     // ------------------------------------------------------
-    KFP_SIMD__INLINE static Int32_128 iota(value_type start)
+    KFP_SIMD__INLINE static Int32_128 indicesSequence(value_type start)
     {
         KFP_SIMD__SPEC_ALIGN(SimdSize) constexpr value_type
         data[SimdLen]{0, 1, 2, 3}; // Helper data array
         return Int32_128{}.load_a(data) + start;
-    }
-    KFP_SIMD__INLINE static Int32_128 seq(value_type start)
-    {
-        return iota(start);
     }
 
     // ------------------------------------------------------
@@ -182,22 +177,18 @@ public:
     }
 
     // ------------------------------------------------------
+    // Print I/O
+    // ------------------------------------------------------
+    // TODO
+
+    // ------------------------------------------------------
     // Data lanes manipulation
     // ------------------------------------------------------
-    KFP_SIMD__INLINE friend Int32_128 select(const Int32_128& mask, const Int32_128& a,
+    KFP_SIMD__INLINE friend Int32_128 select(const Mask32_128& mask, const Int32_128& a,
                                        const Int32_128& b) {
         return select_(mask.data_, a.data_, b.data_);
     }
 
-    KFP_SIMD__INLINE Int32_128& insert(int index, value_type val)
-    {
-        KFP_SIMD__SPEC_ALIGN(SimdSize) value_type
-        data[SimdLen]{}; // Helper data array
-        store_a(data);
-        data[index] = val;
-        load_a(data);
-        return *this;
-    }
     KFP_SIMD__INLINE Int32_128 sign() const
     {
         return Int32_128{
@@ -242,16 +233,6 @@ public:
     // ------------------------------------------------------
     // Print I/O
     // ------------------------------------------------------
-    friend std::ostream& operator<<(std::ostream& stream,
-                                    const Int32_128& a)
-    {
-        KFP_SIMD__SPEC_ALIGN(SimdSize) value_type
-        data[SimdLen]{}; // Helper data array
-        a.store_a(data);
-        stream << "[" << data[0] << ", " << data[1] << ", " << data[2] << ", "
-             << data[3] << "]";
-        return stream;
-    }
 
     // ------------------------------------------------------
     // Basic Arithmetic
@@ -291,26 +272,6 @@ public:
                                    const Int32_128& b)
     {
         a = a * b;
-        return a;
-    }
-    friend Int32_128 operator/(const Int32_128& a,
-                                   const Int32_128& b)
-    {
-        KFP_SIMD__SPEC_ALIGN(SimdSize) value_type
-        data1[SimdLen]{}; // Helper data array
-        a.store_a(data1);
-        KFP_SIMD__SPEC_ALIGN(SimdSize) value_type
-        data2[SimdLen]{}; // Helper data array
-        b.store_a(data2);
-        KFP_SIMD__SPEC_ALIGN(SimdSize) const value_type
-        data[SimdLen]{data1[0] / data2[0], data1[1] / data2[1],
-            data1[2] / data2[2], data1[3] / data2[3]};
-        return Int32_128{ _mm_load_si128(reinterpret_cast<const simd_type*>(data)) };
-    }
-    friend Int32_128& operator/=(Int32_128& a,
-                                   const Int32_128& b)
-    {
-        a = a / b;
         return a;
     }
     friend Int32_128 operator<<(const Int32_128& a, int n)
@@ -394,7 +355,7 @@ public:
         return _mm_abs_epi32(a.data_);
     }
 
-protected:
+private:
     KFP_SIMD__SPEC_ALIGN(SimdSize) simd_type data_;
 };
 

--- a/SSE/int32.h
+++ b/SSE/int32.h
@@ -20,7 +20,7 @@ Emails: mithran@fias.uni-frankfurt.de
 namespace KFP {
 namespace SIMD {
 
-__KFP_SIMD__INLINE __m128i select_(const __m128i& mask, const __m128i& a,
+KFP_SIMD__INLINE __m128i select_(const __m128i& mask, const __m128i& a,
                                     const __m128i& b) {
     return _mm_blendv_epi8(b, a, mask);
 }
@@ -79,7 +79,7 @@ public:
     // ------------------------------------------------------
     static Int32_128 iota(value_type start)
     {
-        __KFP_SIMD__SPEC_ALIGN(SimdSize) constexpr value_type
+        KFP_SIMD__SPEC_ALIGN(SimdSize) constexpr value_type
         data[SimdLen]{0, 1, 2, 3}; // Helper data array
         return Int32_128{}.load_a(data) + start;
     }
@@ -119,7 +119,7 @@ public:
     // ------------------------------------------------------
     Int32_128& gather(const value_type* val_ptr, const Int32_128& index)
     {
-        __KFP_SIMD__SPEC_ALIGN(SimdSize) value_type
+        KFP_SIMD__SPEC_ALIGN(SimdSize) value_type
         indices[SimdLen]{}; // Helper indices array
         index.store_a(indices);
         data_ = _mm_setr_epi32(
@@ -130,11 +130,11 @@ public:
     }
     void scatter(value_type* val_ptr, const Int32_128& index) const
     {
-        __KFP_SIMD__SPEC_ALIGN(SimdSize) value_type
+        KFP_SIMD__SPEC_ALIGN(SimdSize) value_type
         data[SimdLen]{}; // Helper data array
         store_a(data);
 
-        __KFP_SIMD__SPEC_ALIGN(SimdSize) int
+        KFP_SIMD__SPEC_ALIGN(SimdSize) int
         indices[SimdLen]{}; // Helper indices array
         index.store_a(indices);
 
@@ -175,7 +175,7 @@ public:
                ("[Error] (Int32_128::operator[]): invalid index (" + std::to_string(index) +
                ") given. Exceeds maximum")
                .data());
-        __KFP_SIMD__SPEC_ALIGN(SimdSize) value_type
+        KFP_SIMD__SPEC_ALIGN(SimdSize) value_type
         data[SimdLen]{}; // Helper array
         store_a(data);
         return data[index];
@@ -191,7 +191,7 @@ public:
 
     Int32_128& insert(int index, value_type val)
     {
-        __KFP_SIMD__SPEC_ALIGN(SimdSize) value_type
+        KFP_SIMD__SPEC_ALIGN(SimdSize) value_type
         data[SimdLen]{}; // Helper data array
         store_a(data);
         data[index] = val;
@@ -245,7 +245,7 @@ public:
     friend std::ostream& operator<<(std::ostream& stream,
                                     const Int32_128& a)
     {
-        __KFP_SIMD__SPEC_ALIGN(SimdSize) value_type
+        KFP_SIMD__SPEC_ALIGN(SimdSize) value_type
         data[SimdLen]{}; // Helper data array
         a.store_a(data);
         stream << "[" << data[0] << ", " << data[1] << ", " << data[2] << ", "
@@ -296,13 +296,13 @@ public:
     friend Int32_128 operator/(const Int32_128& a,
                                    const Int32_128& b)
     {
-        __KFP_SIMD__SPEC_ALIGN(SimdSize) value_type
+        KFP_SIMD__SPEC_ALIGN(SimdSize) value_type
         data1[SimdLen]{}; // Helper data array
         a.store_a(data1);
-        __KFP_SIMD__SPEC_ALIGN(SimdSize) value_type
+        KFP_SIMD__SPEC_ALIGN(SimdSize) value_type
         data2[SimdLen]{}; // Helper data array
         b.store_a(data2);
-        __KFP_SIMD__SPEC_ALIGN(SimdSize) const value_type
+        KFP_SIMD__SPEC_ALIGN(SimdSize) const value_type
         data[SimdLen]{data1[0] / data2[0], data1[1] / data2[1],
             data1[2] / data2[2], data1[3] / data2[3]};
         return Int32_128{ _mm_load_si128(reinterpret_cast<const simd_type*>(data)) };
@@ -396,7 +396,7 @@ public:
     }
 
 protected:
-    __KFP_SIMD__SPEC_ALIGN(SimdSize) simd_type data_;
+    KFP_SIMD__SPEC_ALIGN(SimdSize) simd_type data_;
 };
 
 } // namespace SIMD

--- a/SSE/int32.h
+++ b/SSE/int32.h
@@ -266,42 +266,42 @@ public:
     friend Mask32_128 operator<(const Int32_128& a,
                                    const Int32_128& b)
     {
-        Mask32_128 result;
+        Mask32_128 result{UninitializeTag{}};
         result.m_data = _mm_cmplt_epi32(a.m_data, b.m_data);
         return result;
     }
     friend Mask32_128 operator<=(const Int32_128& a,
                                     const Int32_128& b)
     {
-        Mask32_128 result;
+        Mask32_128 result{UninitializeTag{}};
         result.m_data = _mm_cmpeq_epi32(_mm_min_epi32(a.m_data, b.m_data), a.m_data);
         return result;
     }
     friend Mask32_128 operator>(const Int32_128& a,
                                    const Int32_128& b)
     {
-        Mask32_128 result;
+        Mask32_128 result{UninitializeTag{}};
         result.m_data = _mm_cmpgt_epi32(a.m_data, b.m_data);
         return result;
     }
     friend Mask32_128 operator>=(const Int32_128& a,
                                     const Int32_128& b)
     {
-        Mask32_128 result;
+        Mask32_128 result{UninitializeTag{}};
         result.m_data = _mm_cmpeq_epi32(_mm_min_epi32(b.m_data, a.m_data), b.m_data);
         return result;
     }
     friend Mask32_128 operator==(const Int32_128& a,
                                     const Int32_128& b)
     {
-        Mask32_128 result;
+        Mask32_128 result{UninitializeTag{}};
         result.m_data = _mm_cmpeq_epi32(a.m_data, b.m_data);
         return result;
     }
     friend Mask32_128 operator!=(const Int32_128& a,
                                     const Int32_128& b)
     {
-        Mask32_128 result;
+        Mask32_128 result{UninitializeTag{}};
         result.m_data = _mm_cmpeq_epi32(a.m_data, b.m_data);
         return not result;
     }

--- a/SSE/int32.h
+++ b/SSE/int32.h
@@ -77,13 +77,13 @@ public:
     // ------------------------------------------------------
     // Factory methods
     // ------------------------------------------------------
-    static Int32_128 iota(value_type start)
+    KFP_SIMD__INLINE static Int32_128 iota(value_type start)
     {
         KFP_SIMD__SPEC_ALIGN(SimdSize) constexpr value_type
         data[SimdLen]{0, 1, 2, 3}; // Helper data array
         return Int32_128{}.load_a(data) + start;
     }
-    static Int32_128 seq(value_type start)
+    KFP_SIMD__INLINE static Int32_128 seq(value_type start)
     {
         return iota(start);
     }
@@ -92,24 +92,24 @@ public:
     // Load and Store
     // ------------------------------------------------------
     // Member function to load from array (unaligned)
-    Int32_128& load(const value_type* val_ptr)
+    KFP_SIMD__INLINE Int32_128& load(const value_type* val_ptr)
     {
         data_ = _mm_loadu_si128(reinterpret_cast<const simd_type*>(val_ptr));
         return *this;
     }
     // Member function to load from array (aligned)
-    Int32_128& load_a(const value_type* val_ptr)
+    KFP_SIMD__INLINE Int32_128& load_a(const value_type* val_ptr)
     {
         data_ = _mm_load_si128(reinterpret_cast<const simd_type*>(val_ptr));
         return *this;
     }
     // Member function to store into array (unaligned)
-    void store(value_type* val_ptr) const
+    KFP_SIMD__INLINE void store(value_type* val_ptr) const
     {
         _mm_storeu_si128(reinterpret_cast<simd_type*>(val_ptr), data_);
     }
     // Member function storing into array (aligned)
-    void store_a(value_type* val_ptr) const
+    KFP_SIMD__INLINE void store_a(value_type* val_ptr) const
     {
         _mm_store_si128(reinterpret_cast<simd_type*>(val_ptr), data_);
     }
@@ -117,7 +117,7 @@ public:
     // ------------------------------------------------------
     // Gather and Scatter
     // ------------------------------------------------------
-    Int32_128& gather(const value_type* val_ptr, const Int32_128& index)
+    KFP_SIMD__INLINE Int32_128& gather(const value_type* val_ptr, const Int32_128& index)
     {
         KFP_SIMD__SPEC_ALIGN(SimdSize) value_type
         indices[SimdLen]{}; // Helper indices array
@@ -128,7 +128,7 @@ public:
         );
         return *this;
     }
-    void scatter(value_type* val_ptr, const Int32_128& index) const
+    KFP_SIMD__INLINE void scatter(value_type* val_ptr, const Int32_128& index) const
     {
         KFP_SIMD__SPEC_ALIGN(SimdSize) value_type
         data[SimdLen]{}; // Helper data array
@@ -147,16 +147,16 @@ public:
     // ------------------------------------------------------
     // Data member accessors
     // ------------------------------------------------------
-    simd_type& simd()
+    KFP_SIMD__INLINE simd_type& simd()
     {
         return data_;
     }
-    const simd_type& simd() const
+    KFP_SIMD__INLINE const simd_type& simd() const
     {
         return data_;
     }
     template <int N>
-    value_type get(simd_type a) const {
+    KFP_SIMD__INLINE value_type get(simd_type a) const {
         static_assert(N < SimdLen,
         "[Error] (Int32_128::get): Invalid value of index to access N given");
 #if 1
@@ -166,7 +166,7 @@ public:
         return _mm_cvtsi128_si32(result);
 #endif
     }
-    value_type operator[](int index) const
+    KFP_SIMD__INLINE value_type operator[](int index) const
     {
         assert((index >= 0) && ("[Error] (Int32_128::operator[]): invalid index (" +
                std::to_string(index) + ") given. Negative")
@@ -184,12 +184,12 @@ public:
     // ------------------------------------------------------
     // Data lanes manipulation
     // ------------------------------------------------------
-    friend Int32_128 select(const Int32_128& mask, const Int32_128& a,
+    KFP_SIMD__INLINE friend Int32_128 select(const Int32_128& mask, const Int32_128& a,
                                        const Int32_128& b) {
         return select_(mask.data_, a.data_, b.data_);
     }
 
-    Int32_128& insert(int index, value_type val)
+    KFP_SIMD__INLINE Int32_128& insert(int index, value_type val)
     {
         KFP_SIMD__SPEC_ALIGN(SimdSize) value_type
         data[SimdLen]{}; // Helper data array
@@ -198,13 +198,13 @@ public:
         load_a(data);
         return *this;
     }
-    Int32_128 sign() const
+    KFP_SIMD__INLINE Int32_128 sign() const
     {
         return Int32_128{
             _mm_and_si128(_mm_set1_epi32(0x80000000), data_)
         };
     }
-    Int32_128& shiftLeft(int n)
+    KFP_SIMD__INLINE Int32_128& shiftLeft(int n)
     {
         constexpr int value_size_bytes = sizeof(int);
         switch (n) {
@@ -221,7 +221,7 @@ public:
         }
         return *this;
     }
-    Int32_128& shiftRight(int n)
+    KFP_SIMD__INLINE Int32_128& shiftRight(int n)
     {
         constexpr int value_size_bytes = sizeof(int);
         switch (n) {
@@ -381,16 +381,15 @@ public:
         return not result;
     }
 
-    friend Int32_128 min(const Int32_128& a, const Int32_128& b)
+    KFP_SIMD__INLINE friend Int32_128 min(const Int32_128& a, const Int32_128& b)
     {
         return _mm_min_epi32(a.data_, b.data_);
     }
-    friend Int32_128 max(const Int32_128& a, const Int32_128& b)
+    KFP_SIMD__INLINE friend Int32_128 max(const Int32_128& a, const Int32_128& b)
     {
         return _mm_max_epi32(a.data_, b.data_);
     }
-
-    friend Int32_128 abs(const Int32_128& a)
+    KFP_SIMD__INLINE friend Int32_128 abs(const Int32_128& a)
     {
         return _mm_abs_epi32(a.data_);
     }

--- a/SSE/mask32.h
+++ b/SSE/mask32.h
@@ -69,7 +69,7 @@ public:
     // Load and Store
     // ------------------------------------------------------
     // Member function to load from array (unaligned)
-    Mask32_128& load(const value_type* val_ptr)
+    KFP_SIMD__INLINE Mask32_128& load(const value_type* val_ptr)
     {
         KFP_SIMD__SPEC_ALIGN(SimdSize) const int
         data[SimdLen]{
@@ -78,13 +78,13 @@ public:
         data_ = _mm_load_si128(reinterpret_cast<const simd_type*>(val_ptr));
         return *this;
     }
-    Mask32_128& loadFromInt(const int* val_ptr)
+    KFP_SIMD__INLINE Mask32_128& loadFromInt(const int* val_ptr)
     {
         data_ = _mm_loadu_si128(reinterpret_cast<const simd_type*>(val_ptr));
         return *this;
     }
     // Member function to store into array (unaligned)
-    void store(value_type* val_ptr) const
+    KFP_SIMD__INLINE void store(value_type* val_ptr) const
     {
         KFP_SIMD__SPEC_ALIGN(SimdSize) int
         data[SimdLen]{}; // Helper data array
@@ -94,7 +94,7 @@ public:
         val_ptr[2] = data[2];
         val_ptr[3] = data[3];
     }
-    void storeToInt(int* val_ptr) const
+    KFP_SIMD__INLINE void storeToInt(int* val_ptr) const
     {
         _mm_storeu_si128(reinterpret_cast<simd_type*>(val_ptr), data_);
     }
@@ -102,7 +102,7 @@ public:
     // ------------------------------------------------------
     // Data member accessors
     // ------------------------------------------------------
-    simd_type& simd()
+    KFP_SIMD__INLINE simd_type& simd()
     {
         return data_;
     }
@@ -110,7 +110,7 @@ public:
     {
         return data_;
     }
-    value_type operator[](int index) const
+    KFP_SIMD__INLINE value_type operator[](int index) const
     {
         assert((index >= 0) && ("[Error] (Mask32_128::operator[]): invalid index (" +
                std::to_string(index) + ") given. Negative")
@@ -125,7 +125,7 @@ public:
         return data[index];
     }
 
-    Mask32_128& insert(int index, value_type val)
+    KFP_SIMD__INLINE Mask32_128& insert(int index, value_type val)
     {
         KFP_SIMD__SPEC_ALIGN(SimdSize) int
         data[SimdLen]{}; // Helper data array
@@ -142,16 +142,16 @@ public:
     // ------------------------------------------------------
     // Basic Arithmetic
     // ------------------------------------------------------
-    int count() const
+    KFP_SIMD__INLINE int count() const
     {
         const int tmp{ _mm_movemask_ps(_mm_castsi128_ps(data_)) };
         return (tmp & 0x01) + ((tmp & 0x02) >> 1) + ((tmp & 0x04) >> 2) + ((tmp & 0x08) >> 3);
     }
-    bool AND() const
+    KFP_SIMD__INLINE bool AND() const
     {
         return _mm_testc_si128(data_, _mm_set1_epi32(-1));
     }
-    bool OR() const
+    KFP_SIMD__INLINE bool OR() const
     {
         return not _mm_testz_si128(data_, data_);
     }

--- a/SSE/mask32.h
+++ b/SSE/mask32.h
@@ -13,9 +13,8 @@ Emails: mithran@fias.uni-frankfurt.de
 #include "../Utils/tag.h"
 #include "constants.h"
 
-#include <cstdint>
-#include <iostream>
 #include <cassert>
+#include <string>
 
 namespace KFP {
 namespace SIMD {
@@ -58,7 +57,7 @@ public:
     {
         return _mm_castsi128_ps(m_data);
     }
-    KFP_SIMD_INLINE bool operator[](int index) const
+    KFP_SIMD_INLINE bool operator[](std::size_t index) const
     {
         assert((index >= 0) && ("[Error] (Mask32_128::operator[]): invalid index (" +
                std::to_string(index) + ") given. Negative")

--- a/SSE/mask32.h
+++ b/SSE/mask32.h
@@ -42,7 +42,7 @@ public:
     }
     Mask32_128(const value_type* val_ptr)
     {
-        __KFP_SIMD__SPEC_ALIGN(SimdSize) const int
+        KFP_SIMD__SPEC_ALIGN(SimdSize) const int
         data[SimdLen]{
             -int(val_ptr[0]), -int(val_ptr[1]), -int(val_ptr[2]), -int(val_ptr[3])
         }; // Helper data array
@@ -71,7 +71,7 @@ public:
     // Member function to load from array (unaligned)
     Mask32_128& load(const value_type* val_ptr)
     {
-        __KFP_SIMD__SPEC_ALIGN(SimdSize) const int
+        KFP_SIMD__SPEC_ALIGN(SimdSize) const int
         data[SimdLen]{
             -int(val_ptr[0]), -int(val_ptr[1]), -int(val_ptr[2]), -int(val_ptr[3])
         }; // Helper data array
@@ -86,7 +86,7 @@ public:
     // Member function to store into array (unaligned)
     void store(value_type* val_ptr) const
     {
-        __KFP_SIMD__SPEC_ALIGN(SimdSize) int
+        KFP_SIMD__SPEC_ALIGN(SimdSize) int
         data[SimdLen]{}; // Helper data array
         _mm_store_si128(reinterpret_cast<simd_type*>(data), data_);
         val_ptr[0] = data[0];
@@ -119,7 +119,7 @@ public:
                ("[Error] (Mask32_128::operator[]): invalid index (" + std::to_string(index) +
                ") given. Exceeds maximum")
                .data());
-        __KFP_SIMD__SPEC_ALIGN(SimdSize) int
+        KFP_SIMD__SPEC_ALIGN(SimdSize) int
         data[SimdLen]{}; // Helper array
         _mm_store_si128(reinterpret_cast<simd_type*>(data), data_);
         return data[index];
@@ -127,7 +127,7 @@ public:
 
     Mask32_128& insert(int index, value_type val)
     {
-        __KFP_SIMD__SPEC_ALIGN(SimdSize) int
+        KFP_SIMD__SPEC_ALIGN(SimdSize) int
         data[SimdLen]{}; // Helper data array
         storeToInt(data);
         data[index] = -int(val);
@@ -188,7 +188,7 @@ public:
     }
 
 protected:
-    __KFP_SIMD__SPEC_ALIGN(SimdSize) simd_type data_;
+    KFP_SIMD__SPEC_ALIGN(SimdSize) simd_type data_;
 };
 
 } // namespace SIMD

--- a/SSE/mask32.h
+++ b/SSE/mask32.h
@@ -13,9 +13,6 @@ Emails: mithran@fias.uni-frankfurt.de
 #include "../Utils/tag.h"
 
 #include <iostream>
-#include <x86intrin.h>
-#include <cmath>
-#include <string>
 #include <cassert>
 
 namespace KFP {
@@ -25,13 +22,173 @@ class Mask32_128
 {
 public:
     typedef bool value_type;
-    typedef __m128 simd_type;
+    typedef __m128i simd_type;
     static constexpr Tag tag{ Tag::SSE };
     static constexpr int SimdSize{ sizeof(simd_type) };
-    static constexpr int SimdLen{ SimdSize / sizeof(int) };
+    static constexpr int SimdLen{ SimdSize / sizeof(value_type) };
+
+    friend class Int32_128;
+    friend class Float32_128;
+
+    // ------------------------------------------------------
+    // Constructors
+    // ------------------------------------------------------
+    // Default constructor:
+    Mask32_128() {}
+    // Constructor to broadcast the same value into all elements:
+    Mask32_128(value_type val)
+    {
+        data_ = _mm_set1_epi32(-int(val));
+    }
+    Mask32_128(const value_type* val_ptr)
+    {
+        __KFP_SIMD__SPEC_ALIGN(SimdSize) const int
+        data[SimdLen]{
+            -int(val_ptr[0]), -int(val_ptr[1]), -int(val_ptr[2]), -int(val_ptr[3])
+        }; // Helper data array
+        data_ = _mm_load_si128(reinterpret_cast<const simd_type*>(val_ptr));
+    }
+    Mask32_128(const Mask32_128& class_simd)
+    {
+        data_ = class_simd.data_;
+    }
+
+    // Assignment constructors:
+    Mask32_128& operator=(value_type val)
+    {
+        data_ = _mm_set1_epi32(-int(val));
+        return *this;
+    }
+    Mask32_128& operator=(const Mask32_128& class_simd)
+    {
+        data_ = class_simd.data_;
+        return *this;
+    }
+
+    // ------------------------------------------------------
+    // Load and Store
+    // ------------------------------------------------------
+    // Member function to load from array (unaligned)
+    Mask32_128& load(const value_type* val_ptr)
+    {
+        __KFP_SIMD__SPEC_ALIGN(SimdSize) const int
+        data[SimdLen]{
+            -int(val_ptr[0]), -int(val_ptr[1]), -int(val_ptr[2]), -int(val_ptr[3])
+        }; // Helper data array
+        data_ = _mm_load_si128(reinterpret_cast<const simd_type*>(val_ptr));
+        return *this;
+    }
+    Mask32_128& loadFromInt(const int* val_ptr)
+    {
+        data_ = _mm_loadu_si128(reinterpret_cast<const simd_type*>(val_ptr));
+        return *this;
+    }
+    // Member function to store into array (unaligned)
+    void store(value_type* val_ptr) const
+    {
+        __KFP_SIMD__SPEC_ALIGN(SimdSize) int
+        data[SimdLen]{}; // Helper data array
+        _mm_store_si128(reinterpret_cast<simd_type*>(data), data_);
+        val_ptr[0] = data[0];
+        val_ptr[1] = data[1];
+        val_ptr[2] = data[2];
+        val_ptr[3] = data[3];
+    }
+    void storeToInt(int* val_ptr) const
+    {
+        _mm_storeu_si128(reinterpret_cast<simd_type*>(val_ptr), data_);
+    }
+
+    // ------------------------------------------------------
+    // Data member accessors
+    // ------------------------------------------------------
+    simd_type& simd()
+    {
+        return data_;
+    }
+    const simd_type& simd() const
+    {
+        return data_;
+    }
+    value_type operator[](int index) const
+    {
+        assert((index >= 0) && ("[Error] (Mask32_128::operator[]): invalid index (" +
+               std::to_string(index) + ") given. Negative")
+               .data());
+        assert((index < SimdLen) &&
+               ("[Error] (Mask32_128::operator[]): invalid index (" + std::to_string(index) +
+               ") given. Exceeds maximum")
+               .data());
+        __KFP_SIMD__SPEC_ALIGN(SimdSize) int
+        data[SimdLen]{}; // Helper array
+        _mm_store_si128(reinterpret_cast<simd_type*>(data), data_);
+        return data[index];
+    }
+
+    Mask32_128& insert(int index, value_type val)
+    {
+        __KFP_SIMD__SPEC_ALIGN(SimdSize) int
+        data[SimdLen]{}; // Helper data array
+        storeToInt(data);
+        data[index] = -int(val);
+        loadFromInt(data);
+        return *this;
+    }
+    // ------------------------------------------------------
+    // Print I/O
+    // ------------------------------------------------------
+    // TODO
+
+    // ------------------------------------------------------
+    // Basic Arithmetic
+    // ------------------------------------------------------
+    int count() const
+    {
+        const int tmp{ _mm_movemask_ps(_mm_castsi128_ps(data_)) };
+        return (tmp & 0x01) + ((tmp & 0x02) >> 1) + ((tmp & 0x04) >> 2) + ((tmp & 0x08) >> 3);
+    }
+    bool AND() const
+    {
+        return _mm_testc_si128(data_, _mm_set1_epi32(-1));
+    }
+    bool OR() const
+    {
+        return not _mm_testz_si128(data_, data_);
+    }
+
+    friend Mask32_128 operator!(const Mask32_128& a)
+    {
+        Mask32_128 result;
+        result.data_ = _mm_xor_si128(_mm_set1_epi32(-1), a.data_);
+        return result;
+    }
+    friend Mask32_128 operator==(const Mask32_128& a, const Mask32_128& b)
+    {
+        Mask32_128 result;
+        result.data_ = _mm_cmpeq_epi32(a.data_, b.data_);
+        return result;
+    }
+    friend Mask32_128 operator!=(const Mask32_128& a, const Mask32_128& b)
+    {
+        Mask32_128 result;
+        result.data_ = _mm_cmpeq_epi32(a.data_, b.data_);
+        return not result;
+    }
+    friend Mask32_128 operator&&(const Mask32_128& a, const Mask32_128& b)
+    {
+        Mask32_128 result;
+        result.data_ = _mm_and_si128(a.data_, b.data_);
+        return result;
+    }
+    friend Mask32_128 operator||(const Mask32_128& a, const Mask32_128& b)
+    {
+        Mask32_128 result;
+        result.data_ = _mm_or_si128(a.data_, b.data_);
+        return result;
+    }
 
 protected:
-    simd_type data_;
+    __KFP_SIMD__SPEC_ALIGN(SimdSize) simd_type data_;
 };
 
 } // namespace SIMD

--- a/SSE/mask32.h
+++ b/SSE/mask32.h
@@ -91,25 +91,25 @@ public:
 
     friend Mask32_128 operator!(const Mask32_128& a)
     {
-        Mask32_128 result;
+        Mask32_128 result{UninitializeTag{}};
         result.m_data = _mm_xor_si128(_mm_set1_epi32(-1), a.m_data);
         return result;
     }
     friend Mask32_128 operator^(const Mask32_128& a, const Mask32_128& b)
     {
-        Mask32_128 result;
+        Mask32_128 result{UninitializeTag{}};
         result.m_data = _mm_xor_si128(a.m_data, b.m_data);
         return result;
     }
     friend Mask32_128 operator&&(const Mask32_128& a, const Mask32_128& b)
     {
-        Mask32_128 result;
+        Mask32_128 result{UninitializeTag{}};
         result.m_data = _mm_and_si128(a.m_data, b.m_data);
         return result;
     }
     friend Mask32_128 operator||(const Mask32_128& a, const Mask32_128& b)
     {
-        Mask32_128 result;
+        Mask32_128 result{UninitializeTag{}};
         result.m_data = _mm_or_si128(a.m_data, b.m_data);
         return result;
     }

--- a/SSE/mask32.h
+++ b/SSE/mask32.h
@@ -106,9 +106,13 @@ public:
     {
         return data_;
     }
-    const simd_type& simd() const
+    KFP_SIMD__INLINE const simd_type& simd() const
     {
         return data_;
+    }
+    KFP_SIMD__INLINE simd_type simdf() const
+    {
+        return _mm_castsi128_ps(data_);
     }
     KFP_SIMD__INLINE value_type operator[](int index) const
     {
@@ -125,15 +129,6 @@ public:
         return data[index];
     }
 
-    KFP_SIMD__INLINE Mask32_128& insert(int index, value_type val)
-    {
-        KFP_SIMD__SPEC_ALIGN(SimdSize) int
-        data[SimdLen]{}; // Helper data array
-        storeToInt(data);
-        data[index] = -int(val);
-        loadFromInt(data);
-        return *this;
-    }
     // ------------------------------------------------------
     // Print I/O
     // ------------------------------------------------------
@@ -147,13 +142,13 @@ public:
         const int tmp{ _mm_movemask_ps(_mm_castsi128_ps(data_)) };
         return (tmp & 0x01) + ((tmp & 0x02) >> 1) + ((tmp & 0x04) >> 2) + ((tmp & 0x08) >> 3);
     }
-    KFP_SIMD__INLINE bool AND() const
+    KFP_SIMD__INLINE bool isFull() const
     {
         return _mm_testc_si128(data_, _mm_set1_epi32(-1));
     }
-    KFP_SIMD__INLINE bool OR() const
+    KFP_SIMD__INLINE bool isEmpty() const
     {
-        return not _mm_testz_si128(data_, data_);
+        return _mm_testz_si128(data_, data_);
     }
 
     friend Mask32_128 operator!(const Mask32_128& a)
@@ -187,7 +182,7 @@ public:
         return result;
     }
 
-protected:
+private:
     KFP_SIMD__SPEC_ALIGN(SimdSize) simd_type data_;
 };
 

--- a/SSE/types.h
+++ b/SSE/types.h
@@ -9,9 +9,9 @@ Emails: mithran@fias.uni-frankfurt.de
 #ifndef SIMD_SSE_TYPE_H
 #define SIMD_SSE_TYPE_H
 
+#include "mask32.h"
 #include "int32.h"
 #include "float32.h"
-#include "mask32.h"
 #include <type_traits>
 
 namespace KFP {
@@ -29,7 +29,7 @@ static_assert(std::is_same<simd_int::value_type, int>::value,
 
 template<typename To, typename From,
 typename std::enable_if<!std::is_same<To, From>::value>::type* = nullptr>
-To type_cast(const From& a)
+To type_cast(const From&)
 {
     throw std::runtime_error("[Error] (KFP::SIMD::type_cast): Invalid types given");
 }
@@ -52,7 +52,7 @@ Int32_128 type_cast<Int32_128, Float32_128>(const Float32_128& a)
 
 template<typename To, typename From,
 typename std::enable_if<!std::is_same<To, From>::value>::type* = nullptr>
-To value_cast(const From& a)
+To value_cast(const From&)
 {
     throw std::runtime_error("[Error] (KFP::SIMD::value_cast): Invalid types given");
 }

--- a/Utils/macros.h
+++ b/Utils/macros.h
@@ -11,41 +11,41 @@ Emails: mithran@fias.uni-frankfurt.de
 
 #include "simd_detect.h"
 
-#define __KFP_SIMD__INLINE inline __attribute__((always_inline))
-#define __KFP_SIMD__INLINE_FORCE inline __attribute__((always_inline))
-#define __KFP_SIMD__ATTR_ALIGN(x) __attribute__((aligned(x)))
-#define __KFP_SIMD__SPEC_ALIGN(x) alignas(x)
+#define KFP_SIMD__INLINE inline __attribute__((always_inline))
+#define KFP_SIMD__INLINE_FORCE inline __attribute__((always_inline))
+#define KFP_SIMD__ATTR_ALIGN(x) __attribute__((aligned(x)))
+#define KFP_SIMD__SPEC_ALIGN(x) alignas(x)
 
-#define __KFP_SIMD__AVX_Size_Int 32
-#define __KFP_SIMD__AVX_Len_Int 8
-#define __KFP_SIMD__AVX_Size_Float 32
-#define __KFP_SIMD__AVX_Len_Float 8
+#define KFP_SIMD__AVX_Size_Int 32
+#define KFP_SIMD__AVX_Len_Int 8
+#define KFP_SIMD__AVX_Size_Float 32
+#define KFP_SIMD__AVX_Len_Float 8
 
-#define __KFP_SIMD__SSE_Size_Int 16
-#define __KFP_SIMD__SSE_Len_Int 4
-#define __KFP_SIMD__SSE_Size_Float 16
-#define __KFP_SIMD__SSE_Len_Float 4
+#define KFP_SIMD__SSE_Size_Int 16
+#define KFP_SIMD__SSE_Len_Int 4
+#define KFP_SIMD__SSE_Size_Float 16
+#define KFP_SIMD__SSE_Len_Float 4
 
-#define __KFP_SIMD__Scalar_Size_Int 4
-#define __KFP_SIMD__Scalar_Len_Int 1
-#define __KFP_SIMD__Scalar_Size_Float 4
-#define __KFP_SIMD__Scalar_Len_Float 1
+#define KFP_SIMD__Scalar_Size_Int 4
+#define KFP_SIMD__Scalar_Len_Int 1
+#define KFP_SIMD__Scalar_Size_Float 4
+#define KFP_SIMD__Scalar_Len_Float 1
 
-#if defined(__KFP_SIMD__AVX)
-#define __KFP_SIMD__Size_Int __KFP_SIMD__AVX_Size_Int
-#define __KFP_SIMD__Len_Int __KFP_SIMD__AVX_Len_Int
-#define __KFP_SIMD__Size_Float __KFP_SIMD__AVX_Size_Float
-#define __KFP_SIMD__Len_Float __KFP_SIMD__AVX_Len_Float
-#elif defined(__KFP_SIMD__SSE)
-#define __KFP_SIMD__Size_Int __KFP_SIMD__SSE_Size_Int
-#define __KFP_SIMD__Len_Int __KFP_SIMD__SSE_Len_Int
-#define __KFP_SIMD__Size_Float __KFP_SIMD__SSE_Size_Float
-#define __KFP_SIMD__Len_Float __KFP_SIMD__SSE_Len_Float
-#elif defined(__KFP_SIMD__Scalar)
-#define __KFP_SIMD__Size_Int __KFP_SIMD__Scalar_Size_Int
-#define __KFP_SIMD__Len_Int __KFP_SIMD__Scalar_Len_Int
-#define __KFP_SIMD__Size_Float __KFP_SIMD__Scalar_Size_Float
-#define __KFP_SIMD__Len_Float __KFP_SIMD__Scalar_Len_Float
+#if defined(KFP_SIMD__AVX)
+#define KFP_SIMD__Size_Int KFP_SIMD__AVX_Size_Int
+#define KFP_SIMD__Len_Int KFP_SIMD__AVX_Len_Int
+#define KFP_SIMD__Size_Float KFP_SIMD__AVX_Size_Float
+#define KFP_SIMD__Len_Float KFP_SIMD__AVX_Len_Float
+#elif defined(KFP_SIMD__SSE)
+#define KFP_SIMD__Size_Int KFP_SIMD__SSE_Size_Int
+#define KFP_SIMD__Len_Int KFP_SIMD__SSE_Len_Int
+#define KFP_SIMD__Size_Float KFP_SIMD__SSE_Size_Float
+#define KFP_SIMD__Len_Float KFP_SIMD__SSE_Len_Float
+#elif defined(KFP_SIMD__Scalar)
+#define KFP_SIMD__Size_Int KFP_SIMD__Scalar_Size_Int
+#define KFP_SIMD__Len_Int KFP_SIMD__Scalar_Len_Int
+#define KFP_SIMD__Size_Float KFP_SIMD__Scalar_Size_Float
+#define KFP_SIMD__Len_Float KFP_SIMD__Scalar_Len_Float
 #else
 #error \
     "[Error] (simd_macros.hpp): Invalid KFParticle SIMD implementation value was selected."

--- a/Utils/macros.h
+++ b/Utils/macros.h
@@ -11,44 +11,6 @@ Emails: mithran@fias.uni-frankfurt.de
 
 #include "simd_detect.h"
 
-#define KFP_SIMD__INLINE inline __attribute__((always_inline))
-#define KFP_SIMD__INLINE_FORCE inline __attribute__((always_inline))
-#define KFP_SIMD__ATTR_ALIGN(x) __attribute__((aligned(x)))
-#define KFP_SIMD__SPEC_ALIGN(x) alignas(x)
-
-#define KFP_SIMD__AVX_Size_Int 32
-#define KFP_SIMD__AVX_Len_Int 8
-#define KFP_SIMD__AVX_Size_Float 32
-#define KFP_SIMD__AVX_Len_Float 8
-
-#define KFP_SIMD__SSE_Size_Int 16
-#define KFP_SIMD__SSE_Len_Int 4
-#define KFP_SIMD__SSE_Size_Float 16
-#define KFP_SIMD__SSE_Len_Float 4
-
-#define KFP_SIMD__Scalar_Size_Int 4
-#define KFP_SIMD__Scalar_Len_Int 1
-#define KFP_SIMD__Scalar_Size_Float 4
-#define KFP_SIMD__Scalar_Len_Float 1
-
-#if defined(KFP_SIMD__AVX)
-#define KFP_SIMD__Size_Int KFP_SIMD__AVX_Size_Int
-#define KFP_SIMD__Len_Int KFP_SIMD__AVX_Len_Int
-#define KFP_SIMD__Size_Float KFP_SIMD__AVX_Size_Float
-#define KFP_SIMD__Len_Float KFP_SIMD__AVX_Len_Float
-#elif defined(KFP_SIMD__SSE)
-#define KFP_SIMD__Size_Int KFP_SIMD__SSE_Size_Int
-#define KFP_SIMD__Len_Int KFP_SIMD__SSE_Len_Int
-#define KFP_SIMD__Size_Float KFP_SIMD__SSE_Size_Float
-#define KFP_SIMD__Len_Float KFP_SIMD__SSE_Len_Float
-#elif defined(KFP_SIMD__Scalar)
-#define KFP_SIMD__Size_Int KFP_SIMD__Scalar_Size_Int
-#define KFP_SIMD__Len_Int KFP_SIMD__Scalar_Len_Int
-#define KFP_SIMD__Size_Float KFP_SIMD__Scalar_Size_Float
-#define KFP_SIMD__Len_Float KFP_SIMD__Scalar_Len_Float
-#else
-#error \
-    "[Error] (simd_macros.hpp): Invalid KFParticle SIMD implementation value was selected."
-#endif
+#define KFP_SIMD_INLINE inline __attribute__((always_inline))
 
 #endif // !SIMD_MACROS_H

--- a/Utils/simd_detect.h
+++ b/Utils/simd_detect.h
@@ -11,84 +11,57 @@ Emails: mithran@fias.uni-frankfurt.de
 
 #include <x86intrin.h>
 
-#ifndef KFP_SIMD
+#ifndef KFP_SIMD_LEVEL
 
 #if defined(__AVX2__)
-#define KFP_SIMD__AVX2 1
+#define KFP_SIMD_AVX2 1
 #elif defined(__AVX__)
-#define KFP_SIMD__AVX 1
+#define KFP_SIMD_AVX 1
 #else
     #if defined(__SSE4_2__)
-    #define KFP_SIMD__SSE4_2 1
+    #define KFP_SIMD_SSE_4p2 1
     #elif defined(__SSE4_1__)
-    #define KFP_SIMD__SSE4_1 1
-    #elif defined(__SSSE3__)
-    #define KFP_SIMD__SSSE3 1
-    #elif defined(__SSE3__)
-    #define KFP_SIMD__SSE3 1
-    #elif defined(__SSE2__)
-    #define KFP_SIMD__SSE2 1
+    #define KFP_SIMD_SSE_4p1 1
     #else
-    #define KFP_SIMD__Scalar 1
+    #define KFP_SIMD_Scalar 1
     #endif
 #endif
 
-#else // KFP_SIMD
+#else // KFP_SIMD_LEVEL
 
-#if KFP_SIMD > 6 // AVX2 supersedes SSE
-#define KFP_SIMD__AVX2 1
-#elif KFP_SIMD > 5 // AVX supersedes SSE
-#define KFP_SIMD__AVX 1
-#elif KFP_SIMD > 4
-#define KFP_SIMD__SSE4_2 1
-#elif KFP_SIMD > 3
-#define KFP_SIMD__SSE4_1 1
-#elif KFP_SIMD > 2
-#define KFP_SIMD__SSSE3 1
-#elif KFP_SIMD > 1
-#define KFP_SIMD__SSE3 1
-#elif KFP_SIMD > 0
-#define KFP_SIMD__SSE2 1
+#if KFP_SIMD_LEVEL > 3 // AVX2 supersedes SSE
+#define KFP_SIMD_AVX2 1
+#elif KFP_SIMD_LEVEL > 2 // AVX supersedes SSE
+#define KFP_SIMD_AVX 1
+#elif KFP_SIMD_LEVEL > 1
+#define KFP_SIMD_SSE_4p2 1
+#elif KFP_SIMD_LEVEL > 0
+#define KFP_SIMD_SSE_4p1 1
 #else
-#define KFP_SIMD__Scalar 1
+#define KFP_SIMD_Scalar 1
 #endif
-#undef KFP_SIMD
-#endif // KFP_SIMD
+#undef KFP_SIMD_LEVEL
+#endif // KFP_SIMD_LEVEL
 
-#if defined(KFP_SIMD__AVX2)
-#define KFP_SIMD__AVX 1
-#endif
-
-#if defined(KFP_SIMD__AVX)
-#define KFP_SIMD__SSE4_2 1
+#if defined(KFP_SIMD_AVX2)
+#define KFP_SIMD_AVX 1
 #endif
 
-#if defined(KFP_SIMD__SSE4_2)
-#define KFP_SIMD__SSE4_1 1
+#if defined(KFP_SIMD_AVX)
+#define KFP_SIMD_SSE_4p2 1
 #endif
 
-#if defined(KFP_SIMD__SSE4_1)
-#define KFP_SIMD__SSSE3 1
+#if defined(KFP_SIMD_SSE_4p2)
+#define KFP_SIMD_SSE_4p1 1
 #endif
 
-#if defined(KFP_SIMD__SSSE3)
-#define KFP_SIMD__SSE3 1
+#if defined(KFP_SIMD_SSE_4p1)
+#define KFP_SIMD_SSE 1
 #endif
 
-#if defined(KFP_SIMD__SSE3)
-#define KFP_SIMD__SSE2 1
-#endif
-
-#if defined(KFP_SIMD__SSE2)
-#define KFP_SIMD__SSE 1
-#endif
-
-#if !defined(KFP_SIMD__Scalar) && !defined(KFP_SIMD__SSE) && !defined(KFP_SIMD__AVX)
+#if !defined(KFP_SIMD_Scalar) && !defined(KFP_SIMD_SSE)
 #error \
     "[Error] (simd_detect.hpp): Invalid KFParticle SIMD implementation value was selected."
-#endif
-#if defined(KFP_SIMD__SSE) && !defined(KFP_SIMD__SSE2)
-#error "[Error] (simd_detect.hpp): KFParticle SIMD implementation value SSE selected without SSE2."
 #endif
 
 #endif // !SIMD_DETECT_H

--- a/Utils/simd_detect.h
+++ b/Utils/simd_detect.h
@@ -11,83 +11,83 @@ Emails: mithran@fias.uni-frankfurt.de
 
 #include <x86intrin.h>
 
-#ifndef __KFP_SIMD__
+#ifndef KFP_SIMD
 
 #if defined(__AVX2__)
-#define __KFP_SIMD__AVX2 1
+#define KFP_SIMD__AVX2 1
 #elif defined(__AVX__)
-#define __KFP_SIMD__AVX 1
+#define KFP_SIMD__AVX 1
 #else
     #if defined(__SSE4_2__)
-    #define __KFP_SIMD__SSE4_2 1
+    #define KFP_SIMD__SSE4_2 1
     #elif defined(__SSE4_1__)
-    #define __KFP_SIMD__SSE4_1 1
+    #define KFP_SIMD__SSE4_1 1
     #elif defined(__SSSE3__)
-    #define __KFP_SIMD__SSSE3 1
+    #define KFP_SIMD__SSSE3 1
     #elif defined(__SSE3__)
-    #define __KFP_SIMD__SSE3 1
+    #define KFP_SIMD__SSE3 1
     #elif defined(__SSE2__)
-    #define __KFP_SIMD__SSE2 1
+    #define KFP_SIMD__SSE2 1
     #else
-    #define __KFP_SIMD__Scalar 1
+    #define KFP_SIMD__Scalar 1
     #endif
 #endif
 
-#else // __KFP_SIMD__
+#else // KFP_SIMD
 
-#if __KFP_SIMD__ > 6 // AVX2 supersedes SSE
-#define __KFP_SIMD__AVX2 1
-#elif __KFP_SIMD__ > 5 // AVX supersedes SSE
-#define __KFP_SIMD__AVX 1
-#elif __KFP_SIMD__ > 4
-#define __KFP_SIMD__SSE4_2 1
-#elif __KFP_SIMD__ > 3
-#define __KFP_SIMD__SSE4_1 1
-#elif __KFP_SIMD__ > 2
-#define __KFP_SIMD__SSSE3 1
-#elif __KFP_SIMD__ > 1
-#define __KFP_SIMD__SSE3 1
-#elif __KFP_SIMD__ > 0
-#define __KFP_SIMD__SSE2 1
+#if KFP_SIMD > 6 // AVX2 supersedes SSE
+#define KFP_SIMD__AVX2 1
+#elif KFP_SIMD > 5 // AVX supersedes SSE
+#define KFP_SIMD__AVX 1
+#elif KFP_SIMD > 4
+#define KFP_SIMD__SSE4_2 1
+#elif KFP_SIMD > 3
+#define KFP_SIMD__SSE4_1 1
+#elif KFP_SIMD > 2
+#define KFP_SIMD__SSSE3 1
+#elif KFP_SIMD > 1
+#define KFP_SIMD__SSE3 1
+#elif KFP_SIMD > 0
+#define KFP_SIMD__SSE2 1
 #else
-#define __KFP_SIMD__Scalar 1
+#define KFP_SIMD__Scalar 1
 #endif
-#undef __KFP_SIMD__
-#endif // __KFP_SIMD__
+#undef KFP_SIMD
+#endif // KFP_SIMD
 
-#if defined(__KFP_SIMD__AVX2)
-#define __KFP_SIMD__AVX 1
-#endif
-
-#if defined(__KFP_SIMD__AVX)
-#define __KFP_SIMD__SSE4_2 1
+#if defined(KFP_SIMD__AVX2)
+#define KFP_SIMD__AVX 1
 #endif
 
-#if defined(__KFP_SIMD__SSE4_2)
-#define __KFP_SIMD__SSE4_1 1
+#if defined(KFP_SIMD__AVX)
+#define KFP_SIMD__SSE4_2 1
 #endif
 
-#if defined(__KFP_SIMD__SSE4_1)
-#define __KFP_SIMD__SSSE3 1
+#if defined(KFP_SIMD__SSE4_2)
+#define KFP_SIMD__SSE4_1 1
 #endif
 
-#if defined(__KFP_SIMD__SSSE3)
-#define __KFP_SIMD__SSE3 1
+#if defined(KFP_SIMD__SSE4_1)
+#define KFP_SIMD__SSSE3 1
 #endif
 
-#if defined(__KFP_SIMD__SSE3)
-#define __KFP_SIMD__SSE2 1
+#if defined(KFP_SIMD__SSSE3)
+#define KFP_SIMD__SSE3 1
 #endif
 
-#if defined(__KFP_SIMD__SSE2)
-#define __KFP_SIMD__SSE 1
+#if defined(KFP_SIMD__SSE3)
+#define KFP_SIMD__SSE2 1
 #endif
 
-#if !defined(__KFP_SIMD__Scalar) && !defined(__KFP_SIMD__SSE) && !defined(__KFP_SIMD__AVX)
+#if defined(KFP_SIMD__SSE2)
+#define KFP_SIMD__SSE 1
+#endif
+
+#if !defined(KFP_SIMD__Scalar) && !defined(KFP_SIMD__SSE) && !defined(KFP_SIMD__AVX)
 #error \
     "[Error] (simd_detect.hpp): Invalid KFParticle SIMD implementation value was selected."
 #endif
-#if defined(__KFP_SIMD__SSE) && !defined(__KFP_SIMD__SSE2)
+#if defined(KFP_SIMD__SSE) && !defined(KFP_SIMD__SSE2)
 #error "[Error] (simd_detect.hpp): KFParticle SIMD implementation value SSE selected without SSE2."
 #endif
 

--- a/Utils/tag.h
+++ b/Utils/tag.h
@@ -14,6 +14,8 @@ Emails: mithran@fias.uni-frankfurt.de
 namespace KFP {
 namespace SIMD {
 
+struct UninitializeTag {};
+
 enum class Tag
 {
     /// uses only fundamental types

--- a/compile_flags.txt
+++ b/compile_flags.txt
@@ -1,10 +1,8 @@
 -xc++
--std=c++17
--mavx2
+-std=c++11
+-march=native
 -Wall
 -Wextra
 -pedantic
 -Weffc++
 -Wsign-conversion
--I
-include/

--- a/simd.h
+++ b/simd.h
@@ -14,27 +14,13 @@ Emails: mithran@fias.uni-frankfurt.de
 #include "Utils/memory.h"
 
 // Select appropriate header files depending on instruction set
-#if defined(KFP_SIMD__AVX)
+#if defined(KFP_SIMD_AVX)
 #include "AVX/types.h"
-#elif defined(KFP_SIMD__SSE)
+#elif defined(KFP_SIMD_SSE)
 #include "SSE/types.h"
 #else
 #error "[Error] (simd.h): KFParticle SIMD Scalar not implemented."
 #include "Scalar/types.h"
 #endif
-
-static_assert(
-    (KFP::SIMD::simd_float::SimdSize == KFP_SIMD__Size_Float),
-    "[Error]: KFP::SIMD::simd_float given invalid size of simd type.");
-static_assert(
-    (KFP::SIMD::simd_float::SimdLen == KFP_SIMD__Len_Float),
-    "[Error]: KFP::SIMD::simd_float given invalid length of simd type.");
-
-static_assert(
-    (KFP::SIMD::simd_int::SimdSize == KFP_SIMD__Size_Int),
-    "[Error]: KFP::SIMD::simd_int given invalid size of simd type.");
-static_assert(
-    (KFP::SIMD::simd_int::SimdLen == KFP_SIMD__Len_Int),
-    "[Error]: KFP::SIMD::simd_int given invalid length of simd type.");
 
 #endif // !KFP_SIMD_H

--- a/simd.h
+++ b/simd.h
@@ -14,9 +14,9 @@ Emails: mithran@fias.uni-frankfurt.de
 #include "Utils/memory.h"
 
 // Select appropriate header files depending on instruction set
-#if defined(__KFP_SIMD__AVX)
+#if defined(KFP_SIMD__AVX)
 #include "AVX/types.h"
-#elif defined(__KFP_SIMD__SSE)
+#elif defined(KFP_SIMD__SSE)
 #include "SSE/types.h"
 #else
 #error "[Error] (simd.h): KFParticle SIMD Scalar not implemented."
@@ -24,17 +24,17 @@ Emails: mithran@fias.uni-frankfurt.de
 #endif
 
 static_assert(
-    (KFP::SIMD::simd_float::SimdSize == __KFP_SIMD__Size_Float),
+    (KFP::SIMD::simd_float::SimdSize == KFP_SIMD__Size_Float),
     "[Error]: KFP::SIMD::simd_float given invalid size of simd type.");
 static_assert(
-    (KFP::SIMD::simd_float::SimdLen == __KFP_SIMD__Len_Float),
+    (KFP::SIMD::simd_float::SimdLen == KFP_SIMD__Len_Float),
     "[Error]: KFP::SIMD::simd_float given invalid length of simd type.");
 
 static_assert(
-    (KFP::SIMD::simd_int::SimdSize == __KFP_SIMD__Size_Int),
+    (KFP::SIMD::simd_int::SimdSize == KFP_SIMD__Size_Int),
     "[Error]: KFP::SIMD::simd_int given invalid size of simd type.");
 static_assert(
-    (KFP::SIMD::simd_int::SimdLen == __KFP_SIMD__Len_Int),
+    (KFP::SIMD::simd_int::SimdLen == KFP_SIMD__Len_Int),
     "[Error]: KFP::SIMD::simd_int given invalid length of simd type.");
 
 #endif // !KFP_SIMD_H


### PR DESCRIPTION
Maksym wrote:

> 1) Assume we always have at least SSE 4.1. Remove all the branches.
> 2) I do not see a need to have Tag.
> 3) For now I would implement operator[] as:
>    float operator[](const int i) const
>    {
>      float tmp[4];
>      _mm_store_ps(tmp, m_data);
>      return tmp[i];
>    }
>    Later I would like to get rid of it.
> 4) Remove pow
> 5) Remove operator/ for integers. If we do not have it - we do not provide it.
> 6) IO operations I would do in a separate file. To be able not to include it. It is resource heavy and not always needed. Lets implement it after we have all other classes.
> 7) Make data type private, we will not inherit.
> 8) Make operators not friends, where possible
> 9) insert is expensive. We do not need it.
> 10) Why do you need a helper select function? I would implement it directly. Also, I would create a mask type common for int and float and use it instead of Int32_128.
>     Something like:
>     class mask_v
>     {
>       public:
>         SIMD_INLINE mask_v(const __m128& a) : m_data(a) {}
>         SIMD_INLINE mask_v(const __m128i& a) : m_data(_mm_castsi128_ps(a)) {}
> 
>         SIMD_INLINE mask_v operator&(const mask_v& a) const { return _mm_and_ps(m_data, a.m_data); }
>         SIMD_INLINE mask_v operator|(const mask_v& a) const { return _mm_or_ps(m_data, a.m_data); }
>         SIMD_INLINE mask_v operator^(const mask_v& a) const { return _mm_xor_ps(m_data, a.m_data); }
> 
>         SIMD_INLINE bool isFull() const { return _mm_test_all_ones(_mm_castps_si128(m_data)); }
>         SIMD_INLINE bool isEmpty() const { return mm_testz_si128(_mm_castps_si128(m_data), mm_castps_si128(m_data)); }
> 
>       private:
>         __m128 m_data;
>     };
> 
> 11) Did you check if compiler optimizes nicely "seq" function? I would call it indicesSequence and get rid of iota, inline everything there manually.
> 12) Forceinline static functions as well.

Akhil wrote:

> 1) I'll keep it for now and remove it at the end. (I can remove it now as well but low priority)
> 2) Tag will be useful for debugging at least.
> 3) Okay. This version is already there. I can make it default. It has fetching memory (could be in cache). The current one has branching disadvantages.
> The templated function should be kept. It is the fastest approach if one knows the index to access.
> 4) Okay.
> 5) Okay but if someone uses it, they need it and they'll make the same or suboptimal version
> 6) A little confusion in this point. Resource heavy at runtime? It happens only if user calls it. Resource heavy at compile time? Other files in KFParticle, KFParticlePerformance and StKFParticleAnalysisMaker are already including <iostream>
> 7) I don't know. I'll keep it protected it for now but I can change later. Low priority
> 8) It is better to keep operators as friends because member functions don’t allow promotion of the left hand argument. Otherwise we should use 'explicit' keyword
> 9) I have had usecases for insert. So I think we should keep it. Unless we find another way to modify specific lanes in the vector.
> We can also keep a templated version which will have best optimization during compile time
> 10) I think select should be kept as separate. Implementing directly would be more suitable when the object is modified instead of a copy. If this is very important we can implement a direct version too.
> Mask is common for both float and int. This was also the case in previous versions
> 11) I will be inlining everything manually.